### PR TITLE
Add 'fileremoved' callback

### DIFF
--- a/fancy-file-uploader/jquery.fancy-fileupload.js
+++ b/fancy-file-uploader/jquery.fancy-fileupload.js
@@ -249,6 +249,7 @@
 						if (settings.uploadcancelled)  settings.uploadcancelled.call(data.ff_info.inforow, e, data);
 					}
 
+					if (settings.fileremoved) settings.fileremoved.call(data.ff_info.inforow, e, data);
 					inforow.remove();
 
 					delete data.ff_info;
@@ -778,7 +779,8 @@
 		'startupload' : null,
 		'continueupload' : null,
 		'uploadcancelled' : null,
-		'uploadcompleted' : null,
+		'uploadcompleted': null,
+		'fileremoved': null,
 		'fileupload' : {},
 		'langmap' : {}
 	};


### PR DESCRIPTION
Adds 'fileremoved' callback, enabling for more control of removed files.

```
        $('#thefiles').FancyFileUpload({
            //your configs...
            fileremoved: function (e, data) {
                let file = data.files[0];
                removeFileServerSide(file)
            }
        });
```


